### PR TITLE
to quick-fix initialization in registry

### DIFF
--- a/R/registry.R
+++ b/R/registry.R
@@ -147,7 +147,7 @@ register_blockr_blocks <- function(pkg) {
 
   register_blocks(
     constructor = c(
-      new_data_block, new_filter_block, new_select_block, new_summarize_block
+      data_block, filter_block, select_block, summarize_block
     ),
     name = c(
       "data block", "filter block", "select block", "summarize block"


### PR DESCRIPTION
Removing the `new_` prefixes.

Superficially, this fixes #181, which seems more a problem of the registry than caused by my PR

@nbenn a good idea to do this?
We should also make sure this doesn't break anything when @JohnCoene is using the registry.