### PR TITLE
Validate filebrowser/upload fields

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -215,16 +215,9 @@ data_block <- function(...) {
 #' @export
 new_upload_block <- function(...) {
 
-  data_path <- function(file) {
-    if (length(file)) file$datapath else character()
-  }
-
   new_block(
-    fields = list(
-      file = new_upload_field(),
-      expression = new_hidden_field(data_path)
-    ),
-    expr = quote(c(.(expression))),
+    fields = list(file = new_upload_field()),
+    expr = quote(.(file)),
     ...,
     class = c("upload_block", "data_block")
   )
@@ -241,23 +234,9 @@ upload_block <- function(...) {
 #' @export
 new_filesbrowser_block <- function(volumes = c(home = path.expand("~")), ...) {
 
-  data_path <- function(file) {
-
-    if (length(file) == 0 || is.integer(file) || length(file$files) == 0) {
-      return(character())
-    }
-
-    files <- shinyFiles::parseFilePaths(volumes, file)
-
-    unname(files$datapath)
-  }
-
   new_block(
-    fields = list(
-      file = new_filesbrowser_field(volumes = volumes),
-      expression = new_hidden_field(data_path)
-    ),
-    expr = quote(c(.(expression))),
+    fields = list(file = new_filesbrowser_field(volumes = volumes)),
+    expr = quote(.(file)),
     ...,
     class = c("filesbrowser_block", "data_block")
   )

--- a/R/field.R
+++ b/R/field.R
@@ -263,11 +263,7 @@ validate_field.submit_field <- function(x) {
 #' @rdname new_field
 #' @export
 new_upload_field <- function(value = character(), ...) {
-  new_field(
-    value,
-    ...,
-    class = "upload_field"
-  )
+  new_field(value, ..., class = "upload_field")
 }
 
 #' @rdname new_field
@@ -279,17 +275,25 @@ upload_field <- function(...) {
 #' @rdname new_field
 #' @export
 validate_field.upload_field <- function(x) {
+
+  val <- value(x)
+
+  if ("datapath" %in% names(val) && file.exists(val$datapath)) {
+    value(x) <- val$datapath
+  } else {
+    value(x) <- character()
+  }
+
   x
 }
 
+#' @param volumes Paths accessible by the shinyFiles browser.
 #' @rdname new_field
 #' @export
-new_filesbrowser_field <- function(value = character(), ...) {
-  new_field(
-    value,
-    ...,
-    class = "filesbrowser_field"
-  )
+new_filesbrowser_field <- function(value = character(),
+                                   volumes = c(home = path.expand("~")), ...) {
+
+  new_field(value, volumes = volumes, ..., class = "filesbrowser_field")
 }
 
 #' @rdname new_field
@@ -301,6 +305,24 @@ filesbrowser_field <- function(...) {
 #' @rdname new_field
 #' @export
 validate_field.filesbrowser_field <- function(x) {
+
+  val <- value(x)
+
+  if (is.list(val) && "files" %in% names(val) && length(val$files)) {
+
+    tmp <- shinyFiles::parseFilePaths(value(x, "volumes"), val)
+
+    if ("datapath" %in% names(tmp) && file.exists(tmp$datapath)) {
+      value(x) <- unname(tmp$datapath)
+    } else {
+      value(x) <- character()
+    }
+
+  } else {
+
+    value(x) <- character()
+  }
+
   x
 }
 

--- a/man/new_field.Rd
+++ b/man/new_field.Rd
@@ -116,7 +116,11 @@ upload_field(...)
 
 \method{validate_field}{upload_field}(x)
 
-new_filesbrowser_field(value = character(), ...)
+new_filesbrowser_field(
+  value = character(),
+  volumes = c(home = path.expand("~")),
+  ...
+)
 
 filesbrowser_field(...)
 
@@ -204,6 +208,8 @@ feature. Default to FALSE. Not yet used.}
 \item{multiple}{Allow multiple selections}
 
 \item{min, max}{Slider boundaries (inclusive)}
+
+\item{volumes}{Paths accessible by the shinyFiles browser.}
 
 \item{name}{Field component name}
 


### PR DESCRIPTION
Fixes #284.

@DivadNojnarg I'm using `validate_field()` to

1. extract the relevant bits in order to get a file name
2. reset if the file for some reason does not exists

what do you think? It makes for very compact blocks.

@JohnCoene you did not provide a reprex, so I could not check whether this fixes your issue. I think it might though. Could you check?