### PR TITLE
Block title

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -143,9 +143,7 @@ block_header <- function(x, ...) {
 #' @rdname block_header
 #' @export
 block_header.block <- function(x, ns, hidden_class, ...) {
-  title <- class(x)[1] |>
-    (\(.) gsub("_.*$", "", .))() |>
-    tools::toTitleCase()
+  title <- get_block_title(x)
 
   div(
     class = sprintf("m-0 card-title block-title %s", hidden_class),

--- a/R/utils.R
+++ b/R/utils.R
@@ -429,16 +429,20 @@ get_block_title <- function(x) {
       trimws() |>
       tools::toTitleCase()
 
+    pkg <- attr(block[[1]], "package")
 
-    return(
-      tagList(
-        span(
-          attr(block[[1]], "package"),
-          class = "badge bg-light"
-        ),
-        name
+    if (length(pkg))
+      return(
+        tagList(
+          span(
+            attr(block[[1]], "package"),
+            class = "badge bg-light"
+          ),
+          name
+        )
       )
-    )
+
+    return(name)
   }
 
   # fallback in case we're working with a block that is not registered

--- a/R/utils.R
+++ b/R/utils.R
@@ -429,7 +429,16 @@ get_block_title <- function(x) {
       trimws() |>
       tools::toTitleCase()
 
-    return(name)
+
+    return(
+      tagList(
+        span(
+          attr(block[[1]], "package"),
+          class = "badge bg-light"
+        ),
+        name
+      )
+    )
   }
 
   # fallback in case we're working with a block that is not registered

--- a/R/utils.R
+++ b/R/utils.R
@@ -436,5 +436,7 @@ get_block_title <- function(x) {
   # e.g.: a block that is defined within the script
   title <- class(x)[1] |>
     (\(.) gsub("_", " ", .))() |>
+    (\(.) gsub("block$", "", .))() |>
+    trimws() |>
     tools::toTitleCase()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -110,7 +110,6 @@ set_names <- function(object = nm, nm) {
 }
 
 coal <- function(..., fail_null = TRUE) {
-
   for (i in seq_len(...length())) {
     x <- ...elt(i)
     if (is.null(x)) next else return(x)
@@ -417,8 +416,9 @@ create_app_link <- function(app_code, mode = c("app", "editor"), header = TRUE) 
 get_block_title <- function(x) {
   registry <- available_blocks()
   block <- registry[sapply(registry, \(blk) {
-    if (all(class(x)[!class(x) %in% "block"] %in% attr(blk, "classes")))
+    if (all(class(x)[!class(x) %in% "block"] %in% attr(blk, "classes"))) {
       return(TRUE)
+    }
 
     FALSE
   })]
@@ -431,7 +431,7 @@ get_block_title <- function(x) {
 
     pkg <- attr(block[[1]], "package")
 
-    if (length(pkg))
+    if (!is.na(pkg)) {
       return(
         tagList(
           span(
@@ -441,6 +441,7 @@ get_block_title <- function(x) {
           name
         )
       )
+    }
 
     return(name)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -413,3 +413,28 @@ create_app_link <- function(app_code, mode = c("app", "editor"), header = TRUE) 
     `data-external` = "1"
   )
 }
+
+get_block_title <- function(x) {
+  registry <- available_blocks()
+  block <- registry[sapply(registry, \(blk) {
+    if (all(class(x)[!class(x) %in% "block"] %in% attr(blk, "classes")))
+      return(TRUE)
+
+    FALSE
+  })]
+
+  if (length(block)) {
+    name <- attr(block[[1]], "name") |>
+      (\(.) gsub("block$", "", .))() |>
+      trimws() |>
+      tools::toTitleCase()
+
+    return(name)
+  }
+
+  # fallback in case we're working with a block that is not registered
+  # e.g.: a block that is defined within the script
+  title <- class(x)[1] |>
+    (\(.) gsub("_", " ", .))() |>
+    tools::toTitleCase()
+}

--- a/tests/testthat/test-block.R
+++ b/tests/testthat/test-block.R
@@ -268,3 +268,7 @@ test_that("xpt parser block", {
 
   expect_s3_class(dat, "data.frame")
 })
+
+test_that("block title", {
+  expect_equal(get_block_title(data_block()), "Data")
+})

--- a/tests/testthat/test-block.R
+++ b/tests/testthat/test-block.R
@@ -270,5 +270,11 @@ test_that("xpt parser block", {
 })
 
 test_that("block title", {
-  expect_equal(get_block_title(data_block()), "Data")
+  expect_equal(
+    get_block_title(data_block()),
+    tagList(
+      span("blockr", class = "badge bg-light"),
+      "Data"
+    )
+  )
 })


### PR DESCRIPTION
Displays better block title.

Attempts to fetch block name from registry by matching registry classes with block classes, if that fails we use a slightly modified version of the current block title.

I think retrieving the name from the registry is a good way to get the name, the fallback is rather naive however as we assume the first class is the custom block class.