### PR TITLE
Use stack result when appending block

### DIFF
--- a/R/stack.R
+++ b/R/stack.R
@@ -178,10 +178,12 @@ add_block <- function(stack, block, position = NULL) {
   stopifnot(is_count(position))
 
   if (position == length(stack)) {
-
     data <- get_stack_result(stack)
+  } else {
+    data <- NULL
+  }
 
-  } else if (length(stack) > 0L) {
+  if (is.null(data) && length(stack) > 0L) {
 
     data <- evaluate_block(stack[[1L]])
 

--- a/R/stack.R
+++ b/R/stack.R
@@ -181,7 +181,7 @@ add_block <- function(stack, block, position = NULL) {
 
     data <- get_stack_result(stack)
 
-  } else {
+  } else if (length(stack) > 0L) {
 
     data <- evaluate_block(stack[[1L]])
 

--- a/R/stack.R
+++ b/R/stack.R
@@ -169,19 +169,26 @@ add_block <- function(stack, block, position = NULL) {
     position <- length(stack)
   }
 
-  log_debug("ADD BLOCK (position ", position + 1, ")")
-
   if (position < 1L) {
     position <- 1L
   }
 
-  # get data from the previous block
-  if (length(stack) == 1) {
-    data <- evaluate_block(stack[[position]])
-  } else if (length(stack) > 1L) {
-    data <- evaluate_block(stack[[1]])
-    for (i in seq_along(stack)[-1L]) {
-      data <- evaluate_block(stack[[i]], data = data)
+  log_debug("ADD BLOCK (position ", position + 1, ")")
+
+  stopifnot(is_count(position))
+
+  if (position == length(stack)) {
+
+    data <- get_stack_result(stack)
+
+  } else {
+
+    data <- evaluate_block(stack[[1L]])
+
+    if (position > 1L) {
+      for (i in seq.int(2L, position)) {
+        data <- evaluate_block(stack[[i]], data = data)
+      }
     }
   }
 


### PR DESCRIPTION
@JohnCoene this should fix the issue where we append a block to the end of the stack, as we there already have the cached stack result available.

If you want to insert a block at an arbitrary position, we could make it work by caching block level results, which we currently don't do and here we have to consider the memory/speed trade-off.