### PR TITLE
Fix missing version constraints and GitHub remotes for dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,8 +47,7 @@ Imports:
     rlang
 Remotes:
     BristolMyersSquibb/blockr.dock,
-    BristolMyersSquibb/blockr.dag,
-    cynkra/g6R
+    BristolMyersSquibb/blockr.dag
 Suggests:
     testthat (>= 3.0.0),
     quarto,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,15 +36,19 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Imports:
-    blockr.core,
-    blockr.dock,
-    blockr.dag,
+    blockr.core (>= 0.1.2),
+    blockr.dock (>= 0.1.1),
+    blockr.dag (>= 0.1.2),
     blockr.dplyr,
     blockr.ggplot,
     blockr.io,
     utils,
     cli,
     rlang
+Remotes:
+    BristolMyersSquibb/blockr.dock,
+    BristolMyersSquibb/blockr.dag,
+    cynkra/g6R
 Suggests:
     testthat (>= 3.0.0),
     quarto,


### PR DESCRIPTION
For #467, though maybe not robust enough, other dependencies might have minimal versions to adjust