### PR TITLE
Replace site with redirect to blockr.site

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,17 +1,10 @@
 name: Deploy site
 
-on:
-  push:
-    branches: main
+on: workflow_dispatch
 
 permissions:
-  contents: read
   pages: write
   id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,12 +1,17 @@
 name: Deploy site
 
 on:
-  repository_dispatch:
-    types: [deploy-site]
+  push:
+    branches: main
 
 permissions:
+  contents: read
   pages: write
   id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -15,21 +20,28 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout blockr-site
-        uses: actions/checkout@v4
+      - name: Create redirect page
+        run: |
+          mkdir -p _site
+          cat > _site/index.html << 'HEREDOC'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=https://blockr.site">
+            <link rel="canonical" href="https://blockr.site">
+            <title>Redirecting to blockr.site</title>
+          </head>
+          <body>
+            <p>This page has moved to <a href="https://blockr.site">blockr.site</a>.</p>
+          </body>
+          </html>
+          HEREDOC
+          cp _site/index.html _site/404.html
+
+      - uses: actions/upload-pages-artifact@v3
         with:
-          repository: BristolMyersSquibb/blockr-site
+          path: _site
 
-      - uses: quarto-dev/quarto-actions/setup@v2
-
-      - name: Render site
-        run: quarto render
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./docs
-
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Replace `deploy-site.yaml` Quarto build with a simple redirect page
- `bristolmyerssquibb.github.io/blockr/` now redirects to `blockr.site`
- No more cross-repo checkout or Quarto rendering needed
- 404 page also redirects to `blockr.site`

## Context
The site is now built and served from the `blockr-site` repo at `blockr.site`.